### PR TITLE
Fix something I noticed when validation was ran

### DIFF
--- a/gitops/flux/runtime/manifests/cluster.yaml
+++ b/gitops/flux/runtime/manifests/cluster.yaml
@@ -89,7 +89,6 @@ spec:
     kind: GitRepository
     name: gitops
   validation: client
-  healthChecks:
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
https://github.com/kingdon-ci/jenkins-infra/pull/27

I only saw that CI validation was failing, this did not cause any actual problems in my cluster. (I did actually get all of the examples to work on my local cluster!)