### PR TITLE
Fixup postrender ambassador

### DIFF
--- a/gitops/flux/runtime/source/ambassador/ambassador-helm-release.yaml
+++ b/gitops/flux/runtime/source/ambassador/ambassador-helm-release.yaml
@@ -23,7 +23,7 @@ spec:
           - kind: Deployment
             apiVersion: apps/v1
             metadata:
-              name: ambassador
+              name: ambassador-edge-stack
               namespace: ambassador
               annotations:
                 config.linkerd.io/skip-inbound-ports: 80,443

--- a/gitops/flux/runtime/source/ambassador/ambassador-helm-release.yaml
+++ b/gitops/flux/runtime/source/ambassador/ambassador-helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 40m
   releaseName: ambassador-edge-stack
   targetNamespace: ambassador
+  storageNamespace: ambassador
   chart:
     spec:
       chart: ambassador


### PR DESCRIPTION
I figured it out

The behavior is different when you ran helm template locally because you set a different release name

I noticed that the Helm Template names the main pod like this:

```
metadata:
  {{- if .Values.deploymentNameOverride }}
  name: {{ .Values.deploymentNameOverride }}
  {{- else }}
  name: {{ include "ambassador.fullname" . }}
  {{- end }}
  namespace: {{ include "ambassador.namespace" . }}
```

Which means if you've used `releaseName: ambassador-edge-stack` then this deployment would be named `ambassador-edge-stack`

I gave it a spin and it came up successfully, you should be able to just merge this in as I haven't changed anything else.

I'll try to rebase my own deployment and custom modifications on this 👍 