### PR TITLE
one more fixup

### DIFF
--- a/gitops/flux/runtime/manifests/cluster.yaml
+++ b/gitops/flux/runtime/manifests/cluster.yaml
@@ -92,15 +92,15 @@ spec:
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment
-      name: ambassador
+      name: ambassador-edge-stack
       namespace: ambassador
     - apiVersion: apps/v1
       kind: Deployment
-      name: ambassador-redis
+      name: ambassador-edge-stack-redis
       namespace: ambassador
     - apiVersion: apps/v1
       kind: Deployment
-      name: ambassador-agent
+      name: ambassador-edge-stack-agent
       namespace: ambassador
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1


### PR DESCRIPTION
I think it needs this too

(Another something to trip over here, hopefully will be fixed with the next Flux release: the default timeout is the same as interval, if you do not set a timeout on Kustomization that is less than interval, then they will be harder to debug.)

The health checks must check the correct resource name based on the helmrelease's releaseName setting